### PR TITLE
Add Docker Compose configuration and startup script for VaultSense services

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,64 @@
+version: '3'
+
+services:  
+  etcd:
+    container_name: milvus-etcd
+    image: quay.io/coreos/etcd:v3.5.0
+    environment:
+      - ETCD_AUTO_COMPACTION_MODE=revision
+      - ETCD_AUTO_COMPACTION_RETENTION=1000
+      - ETCD_QUOTA_BACKEND_BYTES=4294967296
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/etcd:/etcd
+    command: etcd -advertise-client-urls=http://127.0.0.1:2379 -listen-client-urls http://0.0.0.0:2379 --data-dir /etcd
+    networks:
+      - mynetwork
+
+  minio:
+    container_name: milvus-minio
+    image: minio/minio:RELEASE.2020-12-03T00-03-10Z
+    environment:
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/minio:/minio_data
+    command: minio server /minio_data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    networks:
+      - mynetwork
+
+  standalone:
+    container_name: milvus-standalone
+    image: milvusdb/milvus:2.4-20250120-d07ae21e
+    command: ["milvus", "run", "standalone"]
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    volumes:
+      - ${DOCKER_VOLUME_DIRECTORY:-.}/volumes/milvus:/var/lib/milvus
+    ports:
+      - "19530:19530"
+    depends_on:
+      - "etcd"
+      - "minio"
+    networks:
+      - mynetwork
+
+  attu:
+    image: zilliz/attu:latest
+    container_name: attu
+    ports:
+      - "8001:3000"
+    environment:
+      - HOST_URL=http://localhost:8001
+      - MILVUS_URL={LOCAL_MACHINE_IP}:19530
+    networks:
+      - mynetwork
+
+networks:
+  mynetwork:
+    driver: bridge

--- a/start-vaultsense.sh
+++ b/start-vaultsense.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Find the local machine IP address
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Linux
+    LOCAL_IP=$(hostname -I | awk '{print $1}')
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    LOCAL_IP=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1)
+elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "win32" ]]; then
+    # Windows with Git Bash or similar
+    LOCAL_IP=$(ipconfig | grep -i "IPv4 Address" | head -n 1 | awk -F ": " '{print $2}' | tr -d '\r\n')
+else
+    echo "Unsupported operating system. Please manually set your IP address in docker-compose.yaml."
+    exit 1
+fi
+
+if [ -z "$LOCAL_IP" ]; then
+    echo "Could not determine local IP address. Please manually set your IP address in docker-compose.yaml."
+    exit 1
+fi
+
+echo "Detected local IP address: $LOCAL_IP"
+
+# Create temporary docker-compose file and replace the MILVUS_URL line
+# This approach works on both macOS and Linux
+sed "s/- MILVUS_URL=.*$/- MILVUS_URL=$LOCAL_IP:19530/g" docker-compose.yaml > docker-compose.yaml.new
+mv docker-compose.yaml.new docker-compose.yaml
+
+echo "Updated docker-compose.yaml with your local IP address ($LOCAL_IP)"
+
+# Start the docker containers
+echo "Starting VaultSense services..."
+docker-compose up -d
+
+echo "VaultSense services started successfully!"
+echo "You can access the Attu UI at: http://localhost:8001" 


### PR DESCRIPTION
This commit introduces a new `docker-compose.yaml` file to define the services for VaultSense, including etcd, minio, standalone Milvus, and Attu. Additionally, a new script `start-vaultsense.sh` is added to automate the detection of the local machine's IP address and update the Docker Compose file accordingly before starting the services. This setup enhances the deployment process for the VaultSense application.